### PR TITLE
Implement terrain encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.7",
  "once_cell",
  "version_check",
 ]
@@ -779,7 +779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e9aa1866c1cf7ee000f281ce9e90d02d701f5c7380a107252017e58e2f5246"
 dependencies = [
  "ahash",
- "getrandom",
+ "getrandom 0.2.7",
  "hashbrown",
  "instant",
  "tracing",
@@ -819,6 +819,25 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "winit",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb50c5a2ef4b9b1e7ae73e3a73b52ea24b20312d629f9c4df28260b7ad2c3c4"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a45a23389446d2dd25dc8e73a7a3b3c43522b630cac068927f0649d43d719d2"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -1445,6 +1464,19 @@ name = "game"
 version = "0.0.1"
 dependencies = [
  "bevy",
+ "bincode",
+ "rand",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1456,7 +1488,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1985,7 +2017,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -2402,6 +2434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2479,47 @@ name = "radsort"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17fd96390ed3feda12e1dfe2645ed587e0bea749e319333f104a33ff62f77a0b"
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "range-alloc"
@@ -2865,7 +2944,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.7",
  "serde",
 ]
 
@@ -2888,6 +2967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "virtue"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b60dcd6a64dd45abf9bd426970c9843726da7fc08f44cd6fcebf68c21220a63"
+
+[[package]]
 name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,6 +2988,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ opt-level = 3
 [dependencies]
 bevy = { version = "0.8.1", features = ["dynamic"] }
 bincode = { version = "2.0.0-rc.2" }
+rand = { version = "0.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ opt-level = 3
 
 [dependencies]
 bevy = { version = "0.8.1", features = ["dynamic"] }
-
+bincode = { version = "2.0.0-rc.2" }

--- a/src/world.rs
+++ b/src/world.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use crate::states;
 
 use bincode::{Decode, Encode};
+use rand::Rng;
 
 const CHUNK_HEIGHT: usize = 10;
 const CHUNK_WIDTH: usize = 10;
@@ -24,6 +25,7 @@ impl Plugin for WorldPlugin {
         .add_system_set(
             SystemSet::on_update(states::GameState::InGame)
                 .with_system(f2_prints_terrain)
+                .with_system(g_deletes_random_block),
         )
         .add_system_set(SystemSet::on_exit(states::GameState::InGame).with_system(destroy_world));
     }
@@ -365,6 +367,25 @@ fn f2_prints_terrain(input: Res<Input<KeyCode>>, terrain: Res<Terrain>) {
     }
 }
 
+/// Make the G key delete a random block in the first chunk
+fn g_deletes_random_block(
+    input: Res<Input<KeyCode>>,
+    mut commands: Commands,
+    mut terrain: ResMut<Terrain>,
+) {
+    // return early if g was not just pressed
+    if !input.just_pressed(KeyCode::G) {
+        return;
+    }
+
+    let (x, y) = (
+        rand::thread_rng().gen_range(0, CHUNK_WIDTH),
+        rand::thread_rng().gen_range(0, CHUNK_HEIGHT),
+    );
+
+    // don't care about result here
+    let _res = destroy_block(x, y, &mut commands, &mut terrain);
+}
 
 /// unit tests
 #[cfg(test)]

--- a/src/world.rs
+++ b/src/world.rs
@@ -2,8 +2,17 @@ use bevy::prelude::*;
 
 use crate::states;
 
+use bincode::{Decode, Encode};
+
 const CHUNK_HEIGHT: usize = 10;
 const CHUNK_WIDTH: usize = 10;
+
+/// This is the bincode config that we should use everywhere
+/// TODO: move to a better location
+const BINCODE_CONFIG: bincode::config::Configuration = bincode::config::standard()
+    .with_little_endian()
+    .with_variable_int_encoding()
+    .write_fixed_array_length();
 
 pub struct WorldPlugin;
 
@@ -11,6 +20,10 @@ impl Plugin for WorldPlugin {
     fn build(&self, app: &mut App) {
         app.add_system_set(
             SystemSet::on_enter(states::GameState::InGame).with_system(create_world),
+        )
+        .add_system_set(
+            SystemSet::on_update(states::GameState::InGame)
+                .with_system(f2_prints_terrain)
         )
         .add_system_set(SystemSet::on_exit(states::GameState::InGame).with_system(destroy_world));
     }
@@ -20,7 +33,7 @@ pub fn create_world(mut commands: Commands, assets: Res<AssetServer>) {
     info!("creating world");
 
     // create now, insert as resource later
-    let mut terrain = Terrain::default();
+    let mut terrain = Terrain::empty();
 
     // Generate one chunk
     spawn_chunk(0, &mut commands, assets, &mut terrain);
@@ -56,21 +69,31 @@ fn destroy_world(mut commands: Commands, query: Query<Entity, With<RenderedBlock
 
 /// Represents all chunks in the game world
 /// Should be a global resource
+#[derive(Encode, Decode, Debug, PartialEq)]
 pub struct Terrain {
     /// Vector of chunks, each one contains its own chunk_number
     /// TODO: potentially convert into a symbol table for faster lookups?
     chunks: Vec<Chunk>,
 }
 
-impl Default for Terrain {
-    fn default() -> Self {
-        Self {
-            chunks: Default::default(),
+impl Terrain {
+    /// Create a terrain with specified number of chunks
+    /// Chunks contain default blocks and are numbered from 0 to len-1
+    fn new(num_chunks: u64) -> Terrain {
+        Terrain {
+            chunks: (0..num_chunks).map(|d| Chunk::new(d)).collect(),
         }
+    }
+
+    /// Creates a terrain with no chunks
+    fn empty() -> Terrain {
+        Terrain { chunks: Vec::new() }
     }
 }
 
 /// Represents a chunk of blocks; stored in the Terrain resource
+/// TODO: maybe custom bitpack for Encode and Decode?
+#[derive(Encode, Decode, Debug, PartialEq)]
 pub struct Chunk {
     /// 2D array [x, y]
     pub blocks: [[Option<Block>; CHUNK_WIDTH]; CHUNK_HEIGHT],
@@ -93,7 +116,7 @@ impl Chunk {
 }
 
 /// _Not_ a component; stored in a Chunk
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Block {
     /// What kind of block is this
     block_type: BlockType,
@@ -101,12 +124,63 @@ pub struct Block {
     entity: Option<Entity>,
 }
 
+impl Block {
+    /// Easily create a block without an Entity
+    fn new(block_type: BlockType) -> Block {
+        Block {
+            block_type,
+            entity: None,
+        }
+    }
+}
+
+// simple comparison, useful for testing
+impl PartialEq for Block {
+    fn eq(&self, other: &Self) -> bool {
+        // ignore entity differences
+        self.block_type == other.block_type
+    }
+}
+
+// only encode/decode the block type, not the entity
+impl Encode for Block {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        bincode::Encode::encode(&self.block_type, encoder)?;
+        Ok(())
+    }
+}
+
+impl Decode for Block {
+    fn decode<D: bincode::de::Decoder>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        Ok(Self {
+            block_type: bincode::Decode::decode(decoder)?,
+            entity: None,
+        })
+    }
+}
+
+impl<'de> bincode::BorrowDecode<'de> for Block {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        Ok(Self {
+            block_type: bincode::BorrowDecode::borrow_decode(decoder)?,
+            entity: None,
+        })
+    }
+}
+
 /// Marker component for tagging sprite entity for block
 #[derive(Component)]
 pub struct RenderedBlock;
 
 /// A distinct type of block, with its own texture
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Encode, Decode, PartialEq)]
 pub enum BlockType {
     Sandstone,
 }
@@ -240,4 +314,116 @@ fn to_world_point_x(x: usize) -> f32 {
 }
 fn to_world_point_y(y: usize, chunk_number: u64) -> f32 {
     return -(y as f32 + chunk_number as f32 * CHUNK_HEIGHT as f32) * 32.;
+}
+
+fn print_encoding_sizes() {
+    match bincode::encode_to_vec(Block::new(BlockType::Sandstone), BINCODE_CONFIG) {
+        Ok(block) => info!("a sandstone block is {} byte(s)", block.len()),
+        Err(e) => error!("unable to encode block: {}", e),
+    }
+
+    match bincode::encode_to_vec(Chunk::new(0), BINCODE_CONFIG) {
+        Ok(chunk) => info!("a default chunk is {} bytes", chunk.len()),
+        Err(e) => error!("unable to encode chunk: {}", e),
+    }
+
+    match bincode::encode_to_vec(Terrain::new(1), BINCODE_CONFIG) {
+        Ok(terrain) => info!("a default terrain with 1 chunk is {} bytes", terrain.len()),
+        Err(e) => error!("unable to encode terrina: {}", e),
+    }
+}
+
+/// Make the F2 key dump the encoded terrain
+fn f2_prints_terrain(input: Res<Input<KeyCode>>, terrain: Res<Terrain>) {
+    // return early if F2 was not just pressed
+    if !input.just_pressed(KeyCode::F2) {
+        return;
+    }
+
+    print_encoding_sizes();
+
+    // try to encode, allocating a vec
+    // in a real packet, we should use a pre-allocated array and encode into its slice
+    match bincode::encode_to_vec(terrain.as_ref(), BINCODE_CONFIG) {
+        Ok(encoded_vec) => {
+            // we have successfully encoded
+            let mut encoded_str = String::new();
+            // print one long string of bytes, hex representation
+            for byte in &encoded_vec {
+                encoded_str.push_str(&format!("{:02x} ", byte));
+            }
+            info!(
+                "current terrain is {} bytes: {}",
+                encoded_vec.len(),
+                encoded_str
+            );
+        }
+        Err(e) => {
+            // unable to encode
+            error!("unable to encode terrain, {}", e);
+        }
+    }
+}
+
+
+/// unit tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_block() {
+        let original = Block::new(BlockType::Sandstone);
+        let encoded = bincode::encode_to_vec(original, BINCODE_CONFIG).unwrap();
+        let decoded: Block = bincode::decode_from_slice(&encoded, BINCODE_CONFIG)
+            .unwrap()
+            .0;
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn encode_decode_chunk() {
+        let original = {
+            let mut chunk = Chunk::new(0);
+            // change some block
+            chunk.blocks[1][1] = Some(Block::new(BlockType::Sandstone));
+            chunk
+        };
+        let encoded = bincode::encode_to_vec(&original, BINCODE_CONFIG).unwrap();
+        let decoded: Chunk = bincode::decode_from_slice(&encoded, BINCODE_CONFIG)
+            .unwrap()
+            .0;
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn encode_decode_terrain() {
+        let original = {
+            let mut terrain = Terrain::new(2);
+            // change some block
+            terrain.chunks[1].blocks[1][1] = Some(Block::new(BlockType::Sandstone));
+            terrain
+        };
+        let encoded = bincode::encode_to_vec(&original, BINCODE_CONFIG).unwrap();
+        let decoded: Terrain = bincode::decode_from_slice(&encoded, BINCODE_CONFIG)
+            .unwrap()
+            .0;
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn size_sanity_check() {
+        let block_size = bincode::encode_to_vec(Block::new(BlockType::Sandstone), BINCODE_CONFIG)
+            .unwrap()
+            .len();
+        let chunk_size = bincode::encode_to_vec(Chunk::new(0), BINCODE_CONFIG)
+            .unwrap()
+            .len();
+        let terrain_size = bincode::encode_to_vec(Terrain::new(1), BINCODE_CONFIG)
+            .unwrap()
+            .len();
+        assert!(terrain_size > chunk_size);
+        assert!(terrain_size > block_size);
+        assert!(chunk_size > block_size);
+    }
 }


### PR DESCRIPTION
Uses `bincode` to encode and decode, but switching to `serde` is a possibility

Someone still needs to implement writing to and loading from a file

Unit tests verify that blocks, chunks, and terrains can be encoded and then decoded back to the original.

Makes F2 print some debug information about the terrain encoding

Makes G delete a random block

Doesn't do any bitpacking, so the encoding is kinda big and wasteful
- The overall size of the encoding will decrease with each block deletion, since Option<Block> can decode to None (which is smaller) or Some(Block) (which is larger)
- This could be fixed with more manual encoding/decoding