### PR TITLE
add some fixes so that we can see camera following the player

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -181,12 +181,8 @@ fn handle_movement(
             }
         }
 
-        //Handles Gravity, Currently stops at arbitrary height
-        if player_transform.translation.y > -200.0 {
-            player_transform.translation.y += GRAVITY * time.delta_seconds();
-        } else {
-            player_jump_state.state = PlayerJumpState::NonJumping;
-        }
+        //Handles Gravity
+        player_transform.translation.y += GRAVITY * time.delta_seconds();
 
         if let Some(ref terrain) = terrain {
             let player_collision =

--- a/src/world.rs
+++ b/src/world.rs
@@ -7,8 +7,8 @@ use crate::states;
 use bincode::{Decode, Encode};
 use rand::Rng;
 
-pub const CHUNK_HEIGHT: usize = 10;
-pub const CHUNK_WIDTH: usize = 10;
+pub const CHUNK_HEIGHT: usize = 32;
+pub const CHUNK_WIDTH: usize = 32;
 
 /// This is the bincode config that we should use everywhere
 /// TODO: move to a better location
@@ -470,7 +470,7 @@ fn g_deletes_random_block(
     mut terrain: ResMut<Terrain>,
 ) {
     // return early if g was not just pressed
-    if !input.just_pressed(KeyCode::G) {
+    if !input.pressed(KeyCode::G) {
         return;
     }
 


### PR DESCRIPTION
increase world size so it is larger than the screen
holding g destroys lots of blocks (instead of having to press it once per block)
can fall out of world (remove arbitrary y floor)