### PR TITLE
Add simple terrain networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.19"
+version = "4.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e67816e006b17427c9b4386915109b494fec2d929c63e3bd3561234cbf1bf1e"
+checksum = "91b9970d7505127a162fdaa9b96428d28a479ba78c9ec7550a63a5d9863db682"
 dependencies = [
  "atty",
  "bitflags",
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,6 @@ fn main() {
                 .add_plugin(bevy::scene::ScenePlugin);
 
             // TODO:
-            // server world plugin
             // server player plugin
             // server save/load plugin
             app.add_plugin(states::server::StatePlugin);
@@ -45,6 +44,8 @@ fn main() {
                 port: s.port,
                 save_file: s.save_file,
             });
+
+            app.add_plugin(world::server::WorldPlugin);
         }
 
         args::GameArgs::Client(c) => {

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -3,11 +3,12 @@ use std::net::{IpAddr, SocketAddr, UdpSocket};
 use super::*;
 use crate::player;
 use crate::states;
+use crate::world::derender_chunk;
 use crate::world::Terrain;
 use bevy::prelude::*;
 
 /// TODO: move to iyes_loopless
-const NETWORK_TICK_DELAY: u64 = 30;
+const NETWORK_TICK_DELAY: u64 = 60;
 
 /// Should be used as a global resource on the client
 #[derive(Debug)]
@@ -24,6 +25,8 @@ struct Client {
     bodies: Vec<ClientBodyElem>,
     /// Debugging pause: drop all packets in and out, stop any processing
     debug_paused: bool,
+    /// TODO: replace this with iyes_loopless fixedtimestep
+    real_tick_count: u64,
     /// Incoming buffer
     buffer: [u8; BUFFER_SIZE],
 }
@@ -44,6 +47,7 @@ impl Client {
             current_sequence: 0,
             bodies: Vec::with_capacity(DEFAULT_BODIES_VEC_CAPACITY),
             debug_paused: true, // TODO: remove
+            real_tick_count: 0,
             buffer: [0u8; BUFFER_SIZE],
         })
     }
@@ -83,13 +87,28 @@ impl Client {
 
     /// Client logic for handling bodies received from the server
     /// TODO: improve performance by avoiding copies
-    fn handle_body(&mut self, body: ServerBodyElem, terrain: &mut Terrain) {
+    fn handle_body(
+        &mut self,
+        body: ServerBodyElem,
+        commands: &mut Commands,
+        terrain: &mut Terrain,
+    ) {
         match body {
             ServerBodyElem::Pong(pong) => info!("got pong for seqnum: {}", pong),
             ServerBodyElem::Terrain(t) => {
                 // overwrite
                 info!("got terrain, overwriting!");
+
+                // de-render all old chunks
+                for chunk in &mut terrain.chunks {
+                    derender_chunk(commands, chunk);
+                }
+
+                // overwrite the terrain
                 *terrain = t;
+
+                // terrain will be re-rendered as necessary
+
                 info!("done with terrain overwrite");
             }
         }
@@ -137,6 +156,7 @@ fn increase_tick(mut client: ResMut<Client>) {
     // don't increment when paused
     if !client.debug_paused {
         client.current_sequence += 1;
+        client.real_tick_count += 1;
     }
 }
 
@@ -184,7 +204,7 @@ fn p_queues_ping(mut client: ResMut<Client>, input: Res<Input<KeyCode>>) {
 fn queue_inputs(mut client: ResMut<Client>, bevy_input: Res<Input<KeyCode>>) {
     // TODO: remove
     // only send out once every x frames
-    if client.current_sequence % NETWORK_TICK_DELAY != 0 {
+    if client.real_tick_count % NETWORK_TICK_DELAY != 0 {
         return;
     }
 
@@ -204,7 +224,11 @@ fn queue_inputs(mut client: ResMut<Client>, bevy_input: Res<Input<KeyCode>>) {
 }
 
 /// Get and handle all messages from server
-fn client_handle_messages(mut client: ResMut<Client>, mut terrain: ResMut<Terrain>) {
+fn client_handle_messages(
+    mut client: ResMut<Client>,
+    mut terrain: ResMut<Terrain>,
+    mut commands: Commands,
+) {
     if client.debug_paused {
         // eat all the messages
         let mut void = [0u8; 0];
@@ -223,7 +247,7 @@ fn client_handle_messages(mut client: ResMut<Client>, mut terrain: ResMut<Terrai
                 if message.header.sequence > client.last_received_sequence {
                     // handle all bodies sent from the server
                     for body in message.bodies {
-                        client.handle_body(body, &mut terrain);
+                        client.handle_body(body, &mut commands, &mut terrain);
                     }
 
                     // if we are desync'd
@@ -266,7 +290,7 @@ fn send_bodies(mut client: ResMut<Client>) {
 
     // TODO: remove
     // only send out once every x frames
-    if client.current_sequence % NETWORK_TICK_DELAY != 0 {
+    if client.real_tick_count % NETWORK_TICK_DELAY != 0 {
         return;
     }
 

--- a/src/network/common.rs
+++ b/src/network/common.rs
@@ -15,6 +15,10 @@ pub const BINCODE_CONFIG: bincode::config::Configuration = bincode::config::stan
 pub const DEFAULT_SERVER_PORT: u16 = 8888u16;
 pub const DEFAULT_SERVER_IP: [u8; 4] = [127, 0, 0, 1];
 
+/// incoming buffer size for networking
+/// TODO: reduce whenever delta compression is implemented
+pub(super) const BUFFER_SIZE: usize = 65536;
+
 /// Default size of allocated bodies vec, larger numbers may help reduce reallocation
 pub(super) const DEFAULT_BODIES_VEC_CAPACITY: usize = 10;
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -15,7 +15,7 @@ const NETWORK_TICK_HZ: u64 = 1;
 pub const NETWORK_TICK_LABEL: &str = "NETWORK_TICK";
 
 /// how many times per second will the game tick occur
-const GAME_TICK_HZ: u64 = 30;
+const GAME_TICK_HZ: u64 = 60;
 
 /// timestep for doing world calculations
 pub const GAME_TICK_LABEL: &str = "GAME_TICK";

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -8,8 +8,18 @@ use std::{
     path::PathBuf,
 };
 
-const NETWORK_TICK_DELAY: u64 = 60;
-const SERVER_TIMESTEP_LABEL: &'static str = "SERVER_TICK";
+/// how many times per second will the network tick occur
+const NETWORK_TICK_HZ: u64 = 1;
+
+/// timestep for sending out network messages
+pub const NETWORK_TICK_LABEL: &str = "NETWORK_TICK";
+
+/// how many times per second will the game tick occur
+const GAME_TICK_HZ: u64 = 30;
+
+/// timestep for doing world calculations
+pub const GAME_TICK_LABEL: &str = "GAME_TICK";
+
 const MAX_CLIENTS: usize = 2; // final goal = 2, strech goal = 4
 
 /// Should be used as a global resource on the server
@@ -20,6 +30,8 @@ struct Server {
     clients: HashMap<SocketAddr, ClientInfo>,
     /// The current sequence/tick number
     sequence: u64,
+    /// Incoming buffer
+    buffer: [u8; BUFFER_SIZE],
 }
 
 /// Information about a client
@@ -59,6 +71,7 @@ impl Server {
             socket: sock,
             clients: HashMap::with_capacity(MAX_CLIENTS * 2), // avoid resizing (default capacity is 16).,
             sequence: 1u64,
+            buffer: [0u8; BUFFER_SIZE],
         })
     }
 
@@ -80,21 +93,17 @@ impl Server {
     /// Non-blocking way to get one message from the socket
     /// TODO: loop over all clients whenever more than one is supported
     fn get_one_message(&mut self) -> Result<(&mut ClientInfo, ClientToServer), ReceiveError> {
-        // TODO: move buffer into struct
-        let mut buffer = [0u8; 2048];
-
         // read from socket
-        let (_size, sender_addr) =
-            self.socket
-                .recv_from(&mut buffer)
-                .map_err(|e| match e.kind() {
-                    std::io::ErrorKind::WouldBlock => ReceiveError::NoMessage,
-                    _ => ReceiveError::IoError(e),
-                })?;
+        let (_size, sender_addr) = self.socket.recv_from(&mut self.buffer).map_err(|e| match e
+            .kind()
+        {
+            std::io::ErrorKind::WouldBlock => ReceiveError::NoMessage,
+            _ => ReceiveError::IoError(e),
+        })?;
 
         // decode
-        let (message, _size) = bincode::decode_from_slice(&buffer, BINCODE_CONFIG)
-            .map_err(|e| ReceiveError::DecodeError(e))?;
+        let (message, _size) = bincode::decode_from_slice(&self.buffer, BINCODE_CONFIG)
+            .map_err(ReceiveError::DecodeError)?;
 
         // if the server recieves a msg from a new client
         if !self.clients.contains_key(&sender_addr) {
@@ -120,51 +129,65 @@ pub struct ServerPlugin {
 
 impl Plugin for ServerPlugin {
     fn build(&self, app: &mut App) {
+        // add game tick
         app.add_fixed_timestep(
-            std::time::Duration::from_secs_f64(1. / 60.),
-            SERVER_TIMESTEP_LABEL,
-        )
-        .add_enter_system(states::server::GameState::Running, create_server)
-        .add_fixed_timestep_system(
-            SERVER_TIMESTEP_LABEL,
+            std::time::Duration::from_secs_f64(1. / GAME_TICK_HZ as f64),
+            GAME_TICK_LABEL,
+        );
+
+        // add network tick
+        app.add_fixed_timestep(
+            std::time::Duration::from_secs_f64(1. / NETWORK_TICK_HZ as f64),
+            NETWORK_TICK_LABEL,
+        );
+
+        // enter systems
+        app.add_enter_system(states::server::GameState::Running, create_server);
+
+        // exit systems
+        app.add_exit_system(states::server::GameState::Running, destroy_server);
+
+        // game tick systems
+        app.add_fixed_timestep_system(
+            GAME_TICK_LABEL,
             0,
             increase_tick
                 .run_in_state(states::server::GameState::Running)
                 .label("increase_tick"),
         )
         .add_fixed_timestep_system(
-            SERVER_TIMESTEP_LABEL,
+            GAME_TICK_LABEL,
             0,
             server_handle_messages
                 .run_in_state(states::server::GameState::Running)
                 .after("increase_tick")
                 .label("handle_messages"),
-        )
-        .add_fixed_timestep_system(
-            SERVER_TIMESTEP_LABEL,
+        );
+
+        // network tick systems
+        app.add_fixed_timestep_system(
+            NETWORK_TICK_LABEL,
             0,
             enqueue_terrain
                 .run_in_state(states::server::GameState::Running)
-                .after("increase_tick")
                 .label("enqueue_terrain"),
         )
         .add_fixed_timestep_system(
-            SERVER_TIMESTEP_LABEL,
+            NETWORK_TICK_LABEL,
             0,
             send_all_messages
                 .run_in_state(states::server::GameState::Running)
-                .after("handle_messages")
+                .after("enqueue_terrain")
                 .label("send_messages"),
         )
         .add_fixed_timestep_system(
-            SERVER_TIMESTEP_LABEL,
+            NETWORK_TICK_LABEL,
             0,
             drop_disconnected_clients
                 .run_in_state(states::server::GameState::Running)
                 .after("send_messages")
                 .label("drop_disconnected"),
-        )
-        .add_exit_system(states::server::GameState::Running, destroy_server);
+        );
     }
 }
 
@@ -239,6 +262,8 @@ fn compute_new_bodies(client: &mut ClientInfo, message: ClientToServer) {
 
         // reset its drop timer
         client.until_drop = FRAME_DIFFERENCE_BEFORE_DISCONNECT;
+    } else {
+        // message out of oder
     }
 
     // compute our responses
@@ -246,7 +271,7 @@ fn compute_new_bodies(client: &mut ClientInfo, message: ClientToServer) {
         .bodies
         .iter()
         // match client bodies to server bodies
-        .map(|elem| match elem {
+        .filter_map(|elem| match elem {
             ClientBodyElem::Ping => Some(ServerBodyElem::Pong(message.header.current_sequence)),
             ClientBodyElem::Input(_input) => {
                 // TODO: handle player input
@@ -254,10 +279,6 @@ fn compute_new_bodies(client: &mut ClientInfo, message: ClientToServer) {
                 None
             }
         })
-        // ignore any Nones
-        .filter(|response| response.is_some())
-        // we are left with all Somes, so we can unwrap them safely
-        .map(|some| some.unwrap())
         .collect();
 
     // info!(
@@ -279,13 +300,7 @@ fn compute_new_bodies(client: &mut ClientInfo, message: ClientToServer) {
     });
 }
 
-fn send_all_messages(server: ResMut<Server>) {
-    // TODO: remove
-    // only send out once every x frames
-    if server.sequence % NETWORK_TICK_DELAY != 0 {
-        return;
-    }
-
+fn send_all_messages(mut server: ResMut<Server>) {
     // loop over clients
     for (client_addr, client_info) in &server.clients {
         let message = ServerToClient {
@@ -302,34 +317,30 @@ fn send_all_messages(server: ResMut<Server>) {
             Err(e) => error!("server unable to send message: {:?}", e),
         }
     }
+
+    // filter out client bodies
+    for client_info in server.clients.values_mut() {
+        client_info.bodies.retain(|b| match b {
+            ServerBodyElem::Pong(_) => true, // keep pongs until we know they were received
+            ServerBodyElem::Terrain(_) => false, // never keep old terrains
+        });
+    }
 }
 
 /// Add the terrain to the next packet sent
 /// TODO: convert to delta and baseline
-/// TODO: add resource instead of sending static terrain
-fn enqueue_terrain(mut server: ResMut<Server>) {
-    // TODO: remove
-    // only send out once every x frames
-    if server.sequence % NETWORK_TICK_DELAY != 0 {
-        return;
-    }
-
-    for (_, client) in &mut server.clients {
-        let terrain = Terrain::empty();
-        client.bodies.push(ServerBodyElem::Terrain(terrain));
+/// TODO: use reference for terrain instead of clone?
+fn enqueue_terrain(mut server: ResMut<Server>, terrain: Res<Terrain>) {
+    for client in server.clients.values_mut() {
+        client.bodies.push(ServerBodyElem::Terrain(terrain.clone()));
         info!("enqueued terrain");
     }
 }
 
 fn drop_disconnected_clients(mut server: ResMut<Server>) {
-    // TODO: remove
-    if server.sequence % NETWORK_TICK_DELAY != 0 {
-        return;
-    }
-
     // drop clients that haven't responded in a while
     server.clients.retain(|address, client| {
-        let keep = client.until_drop >= NETWORK_TICK_DELAY;
+        let keep = client.until_drop >= GAME_TICK_HZ;
         if !keep {
             warn!("dropping client {}", address);
         }
@@ -338,7 +349,7 @@ fn drop_disconnected_clients(mut server: ResMut<Server>) {
     });
 
     // loop through active clients
-    for (_, client_info) in &mut server.clients {
-        client_info.until_drop -= NETWORK_TICK_DELAY;
+    for client_info in server.clients.values_mut() {
+        client_info.until_drop -= GAME_TICK_HZ;
     }
 }


### PR DESCRIPTION
Implement whole-state (not yet delta) terrain networking
Server maintains an authoritative terrain and sends it to clients
Clients de-render and re-render the whole terrain whenever they get a new one
Client inputs are not yet processed by the server
Player locations are not yet tracked, so the server never generates new chunks
Whenever client networking is enabled (with O), movement and terrain gets buggy